### PR TITLE
Fix hemanth/blns#5: postinstall script should work with non bash shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "test": "mocha",
-    "postinstall": "[ -x \"$(which git)\" ] && git submodule update --init --recursive || echo 'You don't have git installed, so can't update the list'"
+    "postinstall": "[ -x \"$(which git)\" ] && git submodule update --init --recursive || echo \"You don't have git installed, so can't update the list\""
   },
   "files": [
     "index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "blns",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Big List of Naughty Strings.",
   "license": "MIT",
   "repository": "hemanth/blns",
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "test": "mocha",
-    "postinstall": "[[ -x $(which git) ]] && git submodule update --init --recursive || echo 'You don't have git installed, so can't update the list'"
+    "postinstall": "[ -x \"$(which git)\" ] && git submodule update --init --recursive || echo 'You don't have git installed, so can't update the list'"
   },
   "files": [
     "index.js",


### PR DESCRIPTION
This change should resolve #5 and allow the post install to function correctly in a non bash environment.
